### PR TITLE
Add Twitter metadata for link preview

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -36,6 +36,14 @@
   <meta name="keywords" content="{{ site.keywords | default: page.keywords | join:',' }}">
 {% endif %}
 
+{% assign author = site.data.authors[page.author] | default:site.data.authors.first[1] | default:site.author %}
+
+<meta name="twitter:card" content="summary" />
+<meta name="twitter:site" content="@{{ author.social.twitter }}" />
+<meta name="twitter:title" content="{{ title }}" />
+<meta name="twitter:description" content="{{ description | strip_html | truncatewords:50 }}" />
+<meta name="twitter:image" content="{{ author.picture.src }}" />
+
 {% comment %}---------------------------
               LINKS
 ------------------------{% endcomment %}


### PR DESCRIPTION
Hello,

I've started using Hydejack for my blog a couple a days ago and noticed that it didn't work well with Twitter because it does not contain the meta tags required to generate a link preview.

This PR should fix this.

It could be interesting to add a small section in the doc instructing people to run the [validator](https://cards-dev.twitter.com/validator) once to get whitelisted by Twitter.