### PR TITLE
Allow embedding of local download links

### DIFF
--- a/_js/src/push-state.js
+++ b/_js/src/push-state.js
@@ -218,7 +218,7 @@ if (!window.disablePushState && hasFeatures(REQUIREMENTS)) {
 
   new PushState(pushState, {
     replaceIds: ['_main'],
-    linkSelector: 'a[href^="/"]',
+    linkSelector: 'a[href^="/"]:not([download])',
     scriptSelector: 'script:not([type^="math/tex"])',
     duration: DURATION,
     noPopDuration: isSafari,


### PR DESCRIPTION
Providing download links to locally hosted files would not work because the push state engine would intervene the download.