### PR TITLE
Steam Spelling Fix

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -94,7 +94,7 @@ deviantart:
 steam:
   name: Steam
   icon: icon-steam
-  pretend: "http://steamcommunity.com/profiles/"
+  prepend: "http://steamcommunity.com/profiles/"
 dropbox:
   name: Dropbox
   icon: icon-dropbox


### PR DESCRIPTION
pretend: -> prepend:

Steam link functionality wasn't working as the site wasn't pre-pending the url