### PR TITLE
basic GA4 support

### DIFF
--- a/_includes/body/analytics.html
+++ b/_includes/body/analytics.html
@@ -1,43 +1,43 @@
 {% if site.google_analytics %}
-  <script>!function(w, d) {
-    w.ga=w.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+<script>!function (w, d) {
+        window.dataLayer = w.dataLayer || [];
+        function gtag() {dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-    /*{% if site.hydejack.cookies_banner %}*/
-      if (navigator.CookiesOK) {
-        ga('create', '{{ site.google_analytics }}', 'auto');
-      } else if (d.cookie.indexOf("hy--cookies-ok=true") > -1) {
-        ga('create', '{{ site.google_analytics }}', {
-          'storage': 'none',
-          'clientId': localStorage ? localStorage.getItem('ga--client-id') : undefined
+        function gtagConsentDefaultOff() {
+            gtag('consent', 'default', {
+                'ad_storage': 'denied',
+                'analytics_storage': 'denied'
+            });
+        };
+
+        function gtagConsentUpdateOn() {
+            gtag('consent', 'update', {
+                'ad_storage': 'granted',
+                'analytics_storage': 'granted'
+            });
+        };
+
+        /*{% if site.hydejack.cookies_banner %}*/
+        if (navigator.CookiesOK) {
+            /* CookiesOK is not part of the navigator spec, not sure when this is true (extensions?) */
+            /* noop - we activate below */
+        } else if (d.cookie.indexOf("hy--cookies-ok=true") > -1) {
+            /* if cookies are opt-in only and opted for */
+            gtagConsentUpdateOn();
+        } else {
+            /* consent required and not yet given */
+            gtagConsentDefaultOff();
+        }
+        /*{% endif %}*/
+
+        /* start tracking will respect consent if set */
+        gtag('config', '{{ site.google_analytics }}');
+
+        d.addEventListener('hy--cookies-ok', function () {
+            gtagConsentUpdateOn();
         });
-      } else {
-        ga('create', '{{ site.google_analytics }}', {
-          'storage': 'none'
-        });
-        ga('set', 'forceSSL', true);
-        ga('set', 'anonymizeIp', true);
-      }
-    /*{% else %}*/
-      ga('create', '{{ site.google_analytics }}', 'auto');
-    /*{% endif %}*/
 
-    var pushStateEl = d.getElementById('_pushState');
-    var timeoutId;
-    pushStateEl.addEventListener('hy-push-state-load', function() {
-      w.clearTimeout(timeoutId);
-      timeoutId = w.setTimeout(function() {
-        ga('set', 'page', w.location.pathname);
-        ga('send', 'pageview');
-      }, 500);
-    });
-
-    d.addEventListener('hy--cookies-ok', function () {
-      w.ga(function(tracker) {
-        w.ga("set", "anonymizeIp", undefined);
-        localStorage && localStorage.setItem("ga--client-id", tracker.get("clientId"));
-      });
-    });
-
-    w.loadJSDeferred('https://www.google-analytics.com/analytics.js');
-  }(window, document);</script>
+        w.loadJSDeferred('https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}');
+    }(window, document);</script>
 {% endif %}


### PR DESCRIPTION
The old [Universal Analytics support ended on July 1st, 2023](https://support.google.com/analytics/answer/11583528?sjid=14089469775450450929-AP).  This migrates to GA4.

This may resolve https://github.com/hydecorp/hydejack/issues/310

I believe this code is working - at least for the non-PRO case.  I can't test PRO (e.g. cookie banner) since I don't have access.  So I've tried to interpret the old code and *I hope* get close to what was happening there.  **That being said, I'd really suggest testing and likely improving this before merge.** I don't have deep knowledge on Hydejack, GA or even Jekyll. 🤷  This just seems to work for my use-case.

There are some major GA4 changes.  Initialization is different, consent is different and binding to browser history API is automatic if enabled in the GA control panel (default is on).

_I'll be doing further testing of this in the coming week, but wanted to post this as a starting point._

--- 

useful:

[comparison of GA with GTAG function calls](https://developers.google.com/analytics/devguides/migration/ua/analyticsjs-to-gtagjs#measure_pageviews)
https://developers.google.com/tag-platform/security/guides/consent
https://developers.google.com/analytics/devguides/collection/ga4/reference/config
