### PR TITLE
feat(comment): add `giscus` comments plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,3 +72,19 @@ compress_html:
 
 sass:
   style:               compressed
+
+# Setting a giscus data will enable the comment section on
+# pages with `comments: true` in the front matter.
+# See documentation for more information: https://giscus.app
+giscus:
+  repo:                username/repo
+  repo_id:             R_some_repo_id
+  category:            MyCategory
+  category_id:         DIS_some_category_id
+  mapping:             pathname
+  strict:              0
+  reactions_enabled:   1
+  emit_metadata:       0
+  input_position:      bottom
+  theme:               preferred_color_scheme
+  lang:                en

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -35,7 +35,7 @@
         data-reactions-enabled="{{ giscus.reactions_enabled }}"
         data-emit-metadata="{{ giscus.emit_metadata }}"
         data-input-position="{{ giscus.input_position }}"
-        data-theme="preferred_color_scheme"
+        data-theme="{{ giscus.theme }}"
         data-lang="{{ giscus.lang }}"
         crossorigin="anonymous"
         async>

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -22,3 +22,22 @@
   }
 }(window, document);</script>
 {% endif %}
+
+{% assign giscus = site.giscus %}
+{% if giscus %}
+<script src="https://giscus.app/client.js"
+        data-repo="{{ giscus.repo }}"
+        data-repo-id="{{ giscus.repo_id }}"
+        data-category="{{ giscus.category }}"
+        data-category-id="{{ giscus.category_id }}"
+        data-mapping="{{ giscus.mapping }}"
+        data-strict="{{ giscus.strict }}"
+        data-reactions-enabled="{{ giscus.reactions_enabled }}"
+        data-emit-metadata="{{ giscus.emit_metadata }}"
+        data-input-position="{{ giscus.input_position }}"
+        data-theme="preferred_color_scheme"
+        data-lang="{{ giscus.lang }}"
+        crossorigin="anonymous"
+        async>
+</script>
+{% endif %}


### PR DESCRIPTION
Hello there. I have wonder that this project is still in maintenance.

I added `giscus` plugin similar to `disqus`
- For `3rd Party Integrations` section in _config.yml
- giscus: github discussion based comments plugin (https://giscus.app)

Please take a look it