### PR TITLE
Make Disqus work with Hydejack's color toggle and transfer animation 

### DIFF
--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -1,5 +1,17 @@
 {% assign disqus = site.disqus | default:site.disqus_shortname %}
 {% if disqus %}
+
+<!-- Fixing the Disqus iframe transparency issue on some browsers -->
+<style>
+  :root {
+    color-scheme: light dark;
+  }
+  /* make sure Disqus iframe uses light mode */
+  iframe {
+    color-scheme: light;
+  }
+</style>
+
 <div id="disqus_thread"></div>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
 <script>!function(w, d) {

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -34,5 +34,21 @@
       w.loadJSDeferred(d.getElementById("_hrefDisqus").href + 'embed.js');
     }
   }
+
+  d.addEventListener('hydejack-dark-mode-toggle', (e) => {
+    setTimeout(() => {
+      if (w.DISQUS) {
+        w.DISQUS.reset({
+          reload: true,
+          config: function () {
+            this.page.url = w.location.href;
+            this.page.title = d.title;
+            this.page.identifier = w.location.pathname;
+          }
+        });
+      }
+    }, 500);
+  });
+
 }(window, document);</script>
 {% endif %}

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -22,14 +22,16 @@
         config() {
           this.page.url = w.location.href;
           this.page.title = d.title;
+          this.page.identifier = w.location.pathname;
         },
       });
     } else {
       w.disqus_config = function disqusConfig() {
         this.page.url = w.location.href;
         this.page.title = d.title;
+        this.page.identifier = w.location.pathname;
       };
-      w.loadJSDeferred(d.getElementById("_hrefDisqus").href + '/embed.js');
+      w.loadJSDeferred(d.getElementById("_hrefDisqus").href + 'embed.js');
     }
   }
 }(window, document);</script>

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -22,14 +22,14 @@
         config() {
           this.page.url = w.location.href;
           this.page.title = d.title;
-          this.page.identifier = w.location.pathname;
+          this.page.identifier = w.location.pathname.replace(/\/$/,'');
         },
       });
     } else {
       w.disqus_config = function disqusConfig() {
         this.page.url = w.location.href;
         this.page.title = d.title;
-        this.page.identifier = w.location.pathname;
+        this.page.identifier = w.location.pathname.replace(/\/$/,'');
       };
       w.loadJSDeferred(d.getElementById("_hrefDisqus").href + 'embed.js');
     }
@@ -43,7 +43,7 @@
           config: function () {
             this.page.url = w.location.href;
             this.page.title = d.title;
-            this.page.identifier = w.location.pathname;
+            this.page.identifier = w.location.pathname.replace(/\/$/,'');
           }
         });
       }


### PR DESCRIPTION
For the demo, check https://felixnie.github.io. The comment system might change since I'm trying to bring more (like Waline) to my beloved themes, so here is how it looks:

![hydejack-colors-screen-recording](https://github.com/user-attachments/assets/17b63aa4-a4cb-4a3d-8e1c-276887f574a1)

This PR carries out several fixes for issues that most Disqus users will encounter with Hydejack. They are:

- [x] A simple workaround for a dark mode background rendering issue. 
- [x] Refinements for the missing `page.identifier` parameter required by Disqus.
- [x] The closed #244.
- [x] Reset Disqus component after clicking the light mode/dark mode button.  

The first issue is spotted on my Safari browser.

<img width="1470" alt="Snipaste_2025-01-17_20-37-15" src="https://github.com/user-attachments/assets/c776aca0-3a1e-4278-bf4c-c3b8aef81c0f" />

The issue is first spotted on Chrome, and is probably fixed by the Chromium team. (confirmation required)

Link: https://stackoverflow.com/questions/65260505/disqus-iframe-transparency-wont-work-on-chrome-87

The last fix reloads Disqus 500ms after the clicking event. The color transfer animation takes ~250ms. Disqus will check the text color to decide which mode it is. So it's better to wait till the animation finishes. 

Remember to set your dark mode text color properly so that it's bright enough: 

> How is the color scheme determined?
> The light scheme is loaded when the text color Disqus inherits from your site has >= 50% gray contrast: between color: #000000; and color: #787878;
> The dark scheme is loaded in all other instances. 