### PR TITLE
Add Waline comment platform with theme switching

### DIFF
--- a/_includes/head/links-static.html
+++ b/_includes/head/links-static.html
@@ -25,7 +25,7 @@
   <noscript><link rel="stylesheet" href="{{ katex_url }}"></noscript>
 {% endif %}
 
-{% assign disqus = site.disqus | default:site.disqus_shortname %}
+{% assign disqus = site.comments.disqus %}
 {% if disqus %}
-<link rel="dns-prefetch" href="https://{{ disqus }}.disqus.com" id="_hrefDisqus">
+<link rel="dns-prefetch" href="https://{{ disqus.shortname }}.disqus.com" id="_hrefDisqus">
 {% endif %}

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -61,32 +61,54 @@
 
 {% assign waline = site.comments.waline %}
 {% if waline %}
-<!-- Waline CSS -->
-<link
-  rel="stylesheet"
-  href="https://unpkg.com/@waline/client@v3/dist/waline.css"
-/>
+<!-- Add light-mode or dark-mode label to body when missing -->
+<script>
+  (function() {
+    const list = document.body.classList;
+    if (
+      list.contains('dark-mode') || 
+      ('_sunset' in window && !list.contains('light-mode') && matchMedia('(prefers-color-scheme: dark)').matches) 
+    ) {
+      list.add('dark-mode'); 
+      document.documentElement.style.colorScheme = 'dark'; 
+    } else {
+      list.add('light-mode'); 
+      document.documentElement.style.colorScheme = 'light'; 
+    }
+  })();
+</script>
 
-<!-- Waline div -->
+<!-- Load Waline CSS -->
+<link rel="stylesheet" href="https://unpkg.com/@waline/client@v3/dist/waline.css"/>
+
+<!-- Overwrite theme colors -->
+<style>
+  body.dark-mode {
+    --waline-theme-color: #4a6e74;
+    --waline-active-color: #b4d7db;
+    --waline-color: #dddddd;
+    --waline-bg-color: #2a2f31;
+    --waline-bg-color-light: #2a2f31;
+  }
+  body.light-mode {
+    --waline-theme-color: #b4d7db;
+    --waline-active-color: #4a6e74;
+    --waline-color: #444;
+    --waline-bg-color: #fff;
+    --waline-bg-color-light: #f8f8f8;
+  }
+</style>
+
+<!-- Load Waline JS -->
 <div id="waline"></div>
-
-<!-- Waline JS -->
 <script type="module">
   import { init } from 'https://unpkg.com/@waline/client@v3/dist/waline.js';
-
   const waline = init({
     el: '#waline',
     serverURL: '{{ waline.server }}',
-    dark: document.body.classList.contains('dark-mode') ? 'html.dark-mode' : false,
+    dark: 'body.dark-mode',
     lang: '{{ waline.locale | default: "en-US" }}',
     path: window.location.pathname.replace(/\/$/,'')
-  });
-
-  document.addEventListener('hydejack-dark-mode-toggle', (e) => {
-    const isDarkMode = e.detail;
-    waline.update({
-      dark: isDarkMode ? 'html.dark-mode' : false,
-    });
   });
 </script>
 {% endif %}

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -1,5 +1,17 @@
 {% assign disqus = site.disqus | default:site.disqus_shortname %}
 {% if disqus %}
+
+<!-- Fixing the Disqus iframe transparency issue on some browsers -->
+<style>
+  :root {
+    color-scheme: light dark;
+  }
+  /* make sure Disqus iframe uses light mode */
+  iframe {
+    color-scheme: light;
+  }
+</style>
+
 <div id="disqus_thread"></div>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
 <script>!function(w, d) {

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -34,5 +34,21 @@
       w.loadJSDeferred(d.getElementById("_hrefDisqus").href + 'embed.js');
     }
   }
+
+  d.addEventListener('hydejack-dark-mode-toggle', (e) => {
+    setTimeout(() => {
+      if (w.DISQUS) {
+        w.DISQUS.reset({
+          reload: true,
+          config: function () {
+            this.page.url = w.location.href;
+            this.page.title = d.title;
+            this.page.identifier = w.location.pathname;
+          }
+        });
+      }
+    }, 500);
+  });
+
 }(window, document);</script>
 {% endif %}

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -22,14 +22,16 @@
         config() {
           this.page.url = w.location.href;
           this.page.title = d.title;
+          this.page.identifier = w.location.pathname;
         },
       });
     } else {
       w.disqus_config = function disqusConfig() {
         this.page.url = w.location.href;
         this.page.title = d.title;
+        this.page.identifier = w.location.pathname;
       };
-      w.loadJSDeferred(d.getElementById("_hrefDisqus").href + '/embed.js');
+      w.loadJSDeferred(d.getElementById("_hrefDisqus").href + 'embed.js');
     }
   }
 }(window, document);</script>

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -22,14 +22,14 @@
         config() {
           this.page.url = w.location.href;
           this.page.title = d.title;
-          this.page.identifier = w.location.pathname;
+          this.page.identifier = w.location.pathname.replace(/\/$/,'');
         },
       });
     } else {
       w.disqus_config = function disqusConfig() {
         this.page.url = w.location.href;
         this.page.title = d.title;
-        this.page.identifier = w.location.pathname;
+        this.page.identifier = w.location.pathname.replace(/\/$/,'');
       };
       w.loadJSDeferred(d.getElementById("_hrefDisqus").href + 'embed.js');
     }
@@ -43,7 +43,7 @@
           config: function () {
             this.page.url = w.location.href;
             this.page.title = d.title;
-            this.page.identifier = w.location.pathname;
+            this.page.identifier = w.location.pathname.replace(/\/$/,'');
           }
         });
       }

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -1,4 +1,8 @@
-{% assign disqus = site.disqus | default:site.disqus_shortname %}
+{% assign provider = site.comments.provider | default: 'disqus' %}
+
+{% if provider == "disqus" %}
+
+{% assign disqus = site.comments.disqus %}
 {% if disqus %}
 <div id="disqus_thread"></div>
 <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
@@ -21,4 +25,13 @@
     }
   }
 }(window, document);</script>
+{% endif %}
+
+{% elsif provider == "waline" %}
+
+{% assign waline = site.comments.waline %}
+{% if waline %}
+<!-- Waline initialization -->
+{% endif %}
+
 {% endif %}

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -31,7 +31,33 @@
 
 {% assign waline = site.comments.waline %}
 {% if waline %}
-<!-- Waline initialization -->
+<!-- Waline CSS -->
+<link
+  rel="stylesheet"
+  href="https://unpkg.com/@waline/client@v3/dist/waline.css"
+/>
+
+<!-- Waline div -->
+<div id="waline"></div>
+
+<!-- Waline JS -->
+<script type="module">
+  import { init } from 'https://unpkg.com/@waline/client@v3/dist/waline.js';
+
+  const waline = init({
+    el: '#waline',
+    serverURL: '{{ waline.server }}',
+    dark: document.body.classList.contains('dark-mode') ? 'html.dark-mode' : false,
+    lang: '{{ waline.locale | default: "en-US" }}'
+  });
+
+  document.addEventListener('hydejack-dark-mode-toggle', (e) => {
+    const isDarkMode = e.detail;
+    waline.update({
+      dark: isDarkMode ? 'html.dark-mode' : false,
+    });
+  });
+</script>
 {% endif %}
 
 {% endif %}

--- a/_includes/my-comments.html
+++ b/_includes/my-comments.html
@@ -48,7 +48,8 @@
     el: '#waline',
     serverURL: '{{ waline.server }}',
     dark: document.body.classList.contains('dark-mode') ? 'html.dark-mode' : false,
-    lang: '{{ waline.locale | default: "en-US" }}'
+    lang: '{{ waline.locale | default: "en-US" }}',
+    path: window.location.pathname.replace(/\/$/,'')
   });
 
   document.addEventListener('hydejack-dark-mode-toggle', (e) => {


### PR DESCRIPTION
This PR added Waline to the list of commenting systems available for Hydejack.

Demo: https://felixnie.github.io

![Screen Recording 2025-01-19 at 3 40 56 AM](https://github.com/user-attachments/assets/f987899a-6c66-491a-8abf-24af7a3a868f)

Before you start, you may consider changing the layout of the _config.yml file for simple switching between commenting systems:

```
# Setting a disqus shortname will enable the comment section on
# pages with `comments: true` in the front matter.
# disqus:                felixnie

# EDIT: include more comment providers.
comments:
  # 'disqus'/'commento'/'giscus'/'waline'
  provider:            waline

  disqus:
    # If you wanna continue using disqus, you may want to change the way it finds its shortname in _config,yml.
    shortname:         felixnie

  giscus:
    ...
  
  commento:
    ...

  waline:
    server:            "https://comment.felixnie.com"
    locale:            "zh-CN"
```

To make Waline render the right color after page refresh, add the missing label to body: [Added Waline theme switching for Hydejack](https://github.com/hydecorp/hydejack/commit/68701c45fa7ea0b74a1002741cc02d5057947945)

The overwritten CSS makes it match the default theme of Hydejack. Change it to whatever you like.

Compared to Disqus:
1. fast loading time
2. support self-hosting
3. can comment without login
4. rich extensions
5. ...